### PR TITLE
docs: add README video embed

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,6 @@ SproutVideo Downloader is a browser extension built for users who need offline a
 - Keep a browser-first workflow for business and training content
 - Avoid manual stream extraction from embedded players
 
-## Watch The Video
-
-<a href="https://www.youtube.com/watch?v=f7cQfQC-vBk" target="_blank">
-<img src="https://raw.githubusercontent.com/devinschumacher/uploads/refs/heads/main/images/how-to-download-sprout-videos-for-free-chrome-extension-method.jpg" width="700px">
-</a>
-
 ## Links
 
 - :rocket: Get it here: [SproutVideo Downloader](https://serp.ly/sprout-video-downloader)
@@ -26,7 +20,9 @@ SproutVideo Downloader is a browser extension built for users who need offline a
 
 ## Preview
 
-![SproutVideo Downloader workflow preview](https://raw.githubusercontent.com/serpapps/sprout-video-downloader/refs/heads/main/assets/workflow-preview.webp)
+<a href="https://www.youtube.com/watch?v=f7cQfQC-vBk" target="_blank">
+<img src="https://raw.githubusercontent.com/devinschumacher/uploads/refs/heads/main/images/how-to-download-sprout-videos-for-free-chrome-extension-method.jpg" width="700px">
+</a>
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ SproutVideo Downloader is a browser extension built for users who need offline a
 - Keep a browser-first workflow for business and training content
 - Avoid manual stream extraction from embedded players
 
+## Watch The Video
+
+<a href="https://www.youtube.com/watch?v=f7cQfQC-vBk" target="_blank">
+<img src="https://raw.githubusercontent.com/devinschumacher/uploads/refs/heads/main/images/how-to-download-sprout-videos-for-free-chrome-extension-method.jpg" width="700px">
+</a>
+
 ## Links
 
 - :rocket: Get it here: [SproutVideo Downloader](https://serp.ly/sprout-video-downloader)
@@ -20,7 +26,7 @@ SproutVideo Downloader is a browser extension built for users who need offline a
 
 ## Preview
 
-![SproutVideo Downloader workflow preview](assets/workflow-preview.webp)
+![SproutVideo Downloader workflow preview](https://raw.githubusercontent.com/serpapps/sprout-video-downloader/refs/heads/main/assets/workflow-preview.webp)
 
 ## Table of Contents
 


### PR DESCRIPTION
## Summary
- Adds the Watch The Video README section from the reviewed dry-run file
- Converts local README image references to raw GitHub URLs where applicable

## Notes
- This PR was created from the local dry-run README preview.
- No force push was used.
